### PR TITLE
Add event support to react native

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,29 @@ Survicate.leaveScreen("screenName");
 Survicate.setUserId("screenName");
 Survicate.setUserTrait("traitName", "traitValue");
 Survicate.reset();
+
+useEffect(() => {
+  const eventEmitter = new NativeEventEmitter(Survicate);
+  eventEmitter.addListener('onSurveyDisplayed', (event) => {
+    console.debug('Displayed Survey', event);
+  });
+
+  eventEmitter.addListener('onQuestionAnswered', (event) => {
+    console.debug('Question Answered', event);
+  });
+
+  eventEmitter.addListener('onSurveyClosed', (event) => {
+    setShowSurveyButton(false);
+    console.debug('Survey Closed', event);
+  });
+
+  eventEmitter.addListener('onSurveyCompleted', (event) => {
+    setShowSurveyButton(false);
+    console.debug('Survey Completed', event);
+  });
+
+  return () => eventListener.remove();
+}, []);
 ```
 
 ## Changelog

--- a/android/src/main/java/com/survicate/react/SurvicateBindingsModule.java
+++ b/android/src/main/java/com/survicate/react/SurvicateBindingsModule.java
@@ -1,15 +1,31 @@
 package com.survicate.react;
 
+import androidx.annotation.Nullable;
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.survicate.surveys.Survicate;
+import com.survicate.surveys.SurvicateAnswer;
+import com.survicate.surveys.SurvicateEventListener;
 import com.survicate.surveys.traits.UserTrait;
 
 public class SurvicateBindingsModule extends ReactContextBaseJavaModule {
 
     private final ReactApplicationContext reactContext;
+
+    private int listenerCount = 0;
+
+    private void sendEvent(ReactContext reactContext, String eventName, @Nullable WritableMap params) {
+        reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(eventName, params);
+    }
 
     public SurvicateBindingsModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -59,5 +75,81 @@ public class SurvicateBindingsModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void setWorkspaceKey(String workspaceKey) {
         Survicate.setWorkspaceKey(workspaceKey);
+    }
+
+    @ReactMethod
+    public void addListener(String eventName) {
+        if (listenerCount > 0) {
+            return;
+        }
+
+        listenerCount += 1;
+
+        Survicate.setEventListener(new SurvicateEventListener() {
+            @Override
+            public void onSurveyDisplayed(@NonNull String surveyId) {
+                WritableMap params = Arguments.createMap();
+
+                params.putString("surveyId", surveyId);
+
+                sendEvent(reactContext, "onSurveyDisplayed", params);
+            }
+
+            @Override
+            public void onQuestionAnswered(@NonNull String surveyId, long questionId, @NonNull SurvicateAnswer answer) {
+                WritableMap params = Arguments.createMap();
+
+                params.putString("surveyId", surveyId);
+                params.putDouble("questionId", questionId);
+                params.putString("type", answer.getType());
+
+                if (answer.getId() != null) {
+                    params.putDouble("id", answer.getId());
+                }
+
+                if (answer.getIds() != null) {
+                    WritableArray ids = Arguments.createArray();
+                    for(long id: answer.getIds()) {
+                        ids.pushDouble(id);
+                    }
+                    params.putArray("ids", ids);
+                }
+
+                if (answer.getValue() != null) {
+                    params.putString("value", answer.getValue());
+                }
+
+                sendEvent(reactContext, "onQuestionAnswered", params);
+            }
+
+            @Override
+            public void onSurveyClosed(@NonNull String surveyId) {
+                WritableMap params = Arguments.createMap();
+
+                params.putString("surveyId", surveyId);
+
+                sendEvent(reactContext, "onSurveyClosed", params);
+            }
+
+            @Override
+            public void onSurveyCompleted(@NonNull String surveyId) {
+                WritableMap params = Arguments.createMap();
+
+                params.putString("surveyId", surveyId);
+
+                sendEvent(reactContext, "onSurveyCompleted", params);
+            }
+        });
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        if (listenerCount <= 0) {
+            return;
+        }
+
+        listenerCount -= count;
+
+        // TODO: We should remove the listeners here but the Android SDK doesn't support this
     }
 }

--- a/ios/SurvicateBindings.h
+++ b/ios/SurvicateBindings.h
@@ -1,9 +1,11 @@
 #if __has_include("RCTBridgeModule.h")
 #import "RCTBridgeModule.h"
+#import "RCTEventEmitter.h"
 #else
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 #endif
 
-@interface SurvicateBindings : NSObject <RCTBridgeModule>
+@interface SurvicateBindings : RCTEventEmitter <RCTBridgeModule>
 
 @end

--- a/ios/SurvicateBindings.m
+++ b/ios/SurvicateBindings.m
@@ -1,11 +1,51 @@
 #import "SurvicateBindings.h"
+
 @import Survicate;
 
 @implementation SurvicateBindings
+{
+  bool hasListeners;
+}
 
 - (dispatch_queue_t)methodQueue
 {
     return dispatch_get_main_queue();
+}
+
+- (NSArray<NSString*> *)supportedEvents {
+    return @[@"onQuestionAnswered", @"onSurveyClosed", @"onSurveyCompleted", @"onSurveyDisplayed"];
+}
+
+-(void)startObserving {
+    hasListeners = YES;
+}
+
+-(void)stopObserving {
+    hasListeners = NO;
+}
+
+- (void)questionAnsweredWithSurveyId:(NSString * _Nonnull)surveyId questionId:(NSInteger)questionId answer:(SurvicateAnswer * _Nonnull)answer {
+    if (hasListeners) {
+        [self sendEventWithName:@"onQuestionAnswered" body:@{@"surveyId": surveyId}];
+    }
+}
+
+- (void)surveyClosedWithSurveyId:(NSString * _Nonnull)surveyId {
+    if (hasListeners) {
+        [self sendEventWithName:@"onSurveyClosed" body:@{@"surveyId": surveyId}];
+    }
+}
+
+- (void)surveyCompletedWithSurveyId:(NSString * _Nonnull)surveyId {
+    if (hasListeners) {
+        [self sendEventWithName:@"onSurveyCompleted" body:@{@"surveyId": surveyId}];
+    }
+}
+
+- (void)surveyDisplayedWithSurveyId:(NSString * _Nonnull)surveyId {
+    if (hasListeners) {
+        [self sendEventWithName:@"onSurveyDisplayed" body:@{@"surveyId": surveyId}];
+    }
 }
 
 RCT_EXPORT_MODULE()
@@ -38,6 +78,7 @@ RCT_EXPORT_METHOD(setUserTrait:(NSString *)traitName value:(NSString *)value)
 RCT_EXPORT_METHOD(initialize)
 {
     [[SurvicateSdk shared] initialize];
+    [[SurvicateSdk shared] setDelegate:self];
 }
 
 RCT_EXPORT_METHOD(reset)


### PR DESCRIPTION
This is a first attempt at implementing event support.

The android version has one bug in that the Android SDK doesn't support stopping listening to the emitter.
Not sure if this will cause any issues. It hasn't in my testing

For ios android has a warning on the setDelegate call, no idea how to fix as I'm not an Objective C coder. or android for that matter :)